### PR TITLE
Added "Show on Front Page" option + PSR1+2 coding standards

### DIFF
--- a/assets/js/easy-footnotes-admin.js
+++ b/assets/js/easy-footnotes-admin.js
@@ -1,0 +1,12 @@
+jQuery(function() {
+    
+    jQuery("input[name=hide_easy_footnote_after_posts]").click(function() {
+        // only show the "Show on Front page" option when the user has decided NOT to hide the footnotes from the bottom of the posts.
+        // jQuery("#easy_footnote_on_front").toggle(!this.checked); 
+
+        // Disable the "Show on Front page" option when the user has decided NOT to hide the footnotes from the bottom of the posts.
+        jQuery("input[name=show_easy_footnote_on_front]").attr('disabled',this.checked)
+    });
+       
+});
+

--- a/easy-footnotes-admin.php
+++ b/easy-footnotes-admin.php
@@ -16,10 +16,17 @@
 	        $hide_easy_footnote_after_posts = false;
         }
 
+        if (isset( $_POST['show_easy_footnote_on_front'] ) && $_POST['show_easy_footnote_on_front'] ) {
+            $show_easy_footnote_on_front = true;
+        } else {
+            $show_easy_footnote_on_front = false;
+        }
+
         $updateOptions = array(
         	'footnoteLabel' => $easyFootnoteLabel,
             'useLabel' => $easyFootnoteCheck,
             'hide_easy_footnote_after_posts' => $hide_easy_footnote_after_posts,
+            'show_easy_footnote_on_front' => $show_easy_footnote_on_front,
         );
 
         update_option('easy_footnotes_options', $updateOptions);
@@ -32,6 +39,7 @@
         $easyFootnoteLabel = $footnoteOptions['footnoteLabel'];
         $easyFootnoteCheck = $footnoteOptions['useLabel'];
         $hide_easy_footnote_after_posts = $footnoteOptions['hide_easy_footnote_after_posts'];
+        $show_easy_footnote_on_front = $footnoteOptions['show_easy_footnote_on_front'];
     }
 ?>
 
@@ -47,6 +55,8 @@
 		<p><?php esc_html_e("Insert Easy Footnotes Label: "); ?><input type="checkbox" name="easy_footnote_check" <?php checked($easyFootnoteCheck); ?> size="20"><?php esc_html_e(""); ?></p>
 
         <p><?php esc_html_e("Hide Footnotes after post content: "); ?><input type="checkbox" name="hide_easy_footnote_after_posts" <?php checked($hide_easy_footnote_after_posts); ?> size="20"><?php esc_html_e(""); ?></p>
+
+        <p id="easy_footnote_on_front"><?php esc_html_e("Show Footnotes on Front Page: "); ?><input type="checkbox" name="show_easy_footnote_on_front" <?php checked($show_easy_footnote_on_front); ?> size="20"><?php esc_html_e(""); ?></p>
 
         <p class="submit">
         <input type="submit" name="Submit" value="<?php esc_attr_e('Update Options', 'easy_footnotes_trdom' ) ?>" />

--- a/easy-footnotes-admin.php
+++ b/easy-footnotes-admin.php
@@ -1,38 +1,37 @@
 <?php
-	$footnoteOptions = get_option('easy_footnotes_options');
 
-    if ( isset($_POST['easy_footnote_hidden']) && $_POST['easy_footnote_hidden'] == 'Y' ) {
+    $footnoteOptions = get_option('easy_footnotes_options');
+
+    if (isset($_POST['easy_footnote_hidden']) && $_POST['easy_footnote_hidden'] == 'Y') {
         //Form data sent
         $easyFootnoteLabel = $_POST['easy_footnotes_label'];
         if ($_POST['easy_footnote_check']) {
-	        $easyFootnoteCheck = true;
+            $easyFootnoteCheck = true;
         } else {
-	        $easyFootnoteCheck = false;
+            $easyFootnoteCheck = false;
         }
 
-        if (isset( $_POST['hide_easy_footnote_after_posts'] ) && $_POST['hide_easy_footnote_after_posts'] ) {
-	        $hide_easy_footnote_after_posts = true;
+        if (isset($_POST['hide_easy_footnote_after_posts']) && $_POST['hide_easy_footnote_after_posts']) {
+            $hide_easy_footnote_after_posts = true;
         } else {
-	        $hide_easy_footnote_after_posts = false;
+            $hide_easy_footnote_after_posts = false;
         }
 
-        if (isset( $_POST['show_easy_footnote_on_front'] ) && $_POST['show_easy_footnote_on_front'] ) {
+        if (isset($_POST['show_easy_footnote_on_front']) && $_POST['show_easy_footnote_on_front']) {
             $show_easy_footnote_on_front = true;
         } else {
             $show_easy_footnote_on_front = false;
         }
 
         $updateOptions = array(
-        	'footnoteLabel' => $easyFootnoteLabel,
+            'footnoteLabel' => $easyFootnoteLabel,
             'useLabel' => $easyFootnoteCheck,
             'hide_easy_footnote_after_posts' => $hide_easy_footnote_after_posts,
             'show_easy_footnote_on_front' => $show_easy_footnote_on_front,
         );
 
-        update_option('easy_footnotes_options', $updateOptions);
-
-        ?>
-        <div class="updated"><p><strong><?php esc_html_e('Options saved.' ); ?></strong></p></div>
+        update_option('easy_footnotes_options', $updateOptions); ?>
+        <div class="updated"><p><strong><?php esc_html_e('Options saved.'); ?></strong></p></div>
         <?php
     } else {
         //Normal page display
@@ -44,11 +43,11 @@
 ?>
 
 <div class="wrap">
-    <?php echo "<h2>" . esc_html__( 'Easy Footnotes Settings', 'easy_footnotes_trdom' ) . "</h2>"; ?>
+    <?php echo "<h2>" . esc_html__('Easy Footnotes Settings', 'easy_footnotes_trdom') . "</h2>"; ?>
 
-    <form name="easy_footnotes_form" method="post" action="<?php echo str_replace( '%7E', '~', $_SERVER['REQUEST_URI']); ?>">
+    <form name="easy_footnotes_form" method="post" action="<?php echo str_replace('%7E', '~', $_SERVER['REQUEST_URI']); ?>">
     	<input type="hidden" name="easy_footnote_hidden" value="Y">
-        <?php echo "<h4>" . esc_html__( 'Easy Footnotes Settings', 'easy_footnotes_trdom' ) . "</h4>"; ?>
+        <?php echo "<h4>" . esc_html__('Easy Footnotes Settings', 'easy_footnotes_trdom') . "</h4>"; ?>
 		<p><?php esc_html_e("Want to add a label to your footnotes section at the bottom of your post? Just enter some text here and check the box and you're good to go."); ?></p>
         <p><?php esc_html_e("Easy Footnotes Label: "); ?><input type="text" name="easy_footnotes_label" value="<?php echo esc_attr($easyFootnoteLabel); ?>" size="20"></p>
 
@@ -59,7 +58,7 @@
         <p id="easy_footnote_on_front"><?php esc_html_e("Show Footnotes on Front Page: "); ?><input type="checkbox" name="show_easy_footnote_on_front" <?php checked($show_easy_footnote_on_front); ?> size="20"><?php esc_html_e(""); ?></p>
 
         <p class="submit">
-        <input type="submit" name="Submit" value="<?php esc_attr_e('Update Options', 'easy_footnotes_trdom' ) ?>" />
+        <input type="submit" name="Submit" value="<?php esc_attr_e('Update Options', 'easy_footnotes_trdom') ?>" />
         </p>
     </form>
 
@@ -68,12 +67,12 @@
     </div>
 
 	<div class="efn-preview">
-		<a class="efn-theme-link" href="<?php echo esc_url( 'https://www.themes.pizza/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell' ); ?>" target="_blank"><img src="<?php echo plugins_url( '/assets/zuul-wordpress-theme.jpg' , __FILE__ ); ?>" alt="Zuul WordPress Theme homepage in various color options" /></a>
+		<a class="efn-theme-link" href="<?php echo esc_url('https://www.themes.pizza/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell'); ?>" target="_blank"><img src="<?php echo plugins_url('/assets/zuul-wordpress-theme.jpg', __FILE__); ?>" alt="Zuul WordPress Theme homepage in various color options" /></a>
 		<div class="efn-preview-copy">
-			<h2><?php echo __( 'Tasty WordPress Themes', 'easy-footnotes' ); ?></h2>
-			<p><?php printf( __( 'Love easy footnotes? Check out my premium themes now available on Themes.Pizza. Each theme is hand crafted from the finest ingredients with a specific purpose in mind. Need to start a side project / membership site? Try out <a href="%1s" target="_blank">Zuul</a>. Looking to establish yourself as an authoirty on a subject? Try out <a href="%2s" target="_blank">The Authority Pro</a>.', 'easy-footnotes' ), esc_url( 'https://www.themes.pizza/downloads/zuul-pro/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell' ), esc_url( 'https://www.themes.pizza/downloads/the-authority-pro/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell' ) ); ?></p>
-			<p><?php echo __( 'All themes are 100% GPL. Use them on as many sites as you want and make something awesome! And for being a faithful Easy Footnotes user get 20% off with the code <strong>TASTYZA</strong>.', 'easy-footnotes' ); ?></p>
-			<a class="efn-theme-button" href="<?php echo esc_url( 'https://www.themes.pizza/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell' ); ?>" target="_blank"><?php echo __( 'Shop Now', 'easy-footnotes' ); ?></a>
+			<h2><?php echo __('Tasty WordPress Themes', 'easy-footnotes'); ?></h2>
+			<p><?php printf(__('Love easy footnotes? Check out my premium themes now available on Themes.Pizza. Each theme is hand crafted from the finest ingredients with a specific purpose in mind. Need to start a side project / membership site? Try out <a href="%1s" target="_blank">Zuul</a>. Looking to establish yourself as an authoirty on a subject? Try out <a href="%2s" target="_blank">The Authority Pro</a>.', 'easy-footnotes'), esc_url('https://www.themes.pizza/downloads/zuul-pro/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell'), esc_url('https://www.themes.pizza/downloads/the-authority-pro/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell')); ?></p>
+			<p><?php echo __('All themes are 100% GPL. Use them on as many sites as you want and make something awesome! And for being a faithful Easy Footnotes user get 20% off with the code <strong>TASTYZA</strong>.', 'easy-footnotes'); ?></p>
+			<a class="efn-theme-button" href="<?php echo esc_url('https://www.themes.pizza/?utm_source=easy-footnotes&utm_medium=button&utm_campaign=efnupsell'); ?>" target="_blank"><?php echo __('Shop Now', 'easy-footnotes'); ?></a>
 		</div>
 	</div>
 </div>

--- a/easy-footnotes.php
+++ b/easy-footnotes.php
@@ -25,187 +25,178 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-class easyFootnotes {
+class easyFootnotes
+{
 
-	// Add label option using add_option if it does not already exist
-	public $footnotes = array();
-	public $footnoteCount = 0;
-	public $prevPost;
-	public $footnoteOptions;
+    // Add label option using add_option if it does not already exist
+    public $footnotes = array();
+    public $footnoteCount = 0;
+    public $prevPost;
+    public $footnoteOptions;
 
-	private $footnoteSettings = array(
-			'footnoteLabel' => 'Footnotes',
-			'useLabel' => false,
-			'hide_easy_footnote_after_posts' => false,
-			'show_easy_footnote_on_front' => false
-		);
+    private $footnoteSettings = array(
+            'footnoteLabel' => 'Footnotes',
+            'useLabel' => false,
+            'hide_easy_footnote_after_posts' => false,
+            'show_easy_footnote_on_front' => false
+        );
 
-	public function __construct() {
-		
+    public function __construct()
+    {
+        add_option('easy_footnotes_options', $this->footnoteSettings);
+        add_shortcode('note', array($this, 'easy_footnote_shortcode'));
+        add_filter('the_content', array($this, 'easy_footnote_after_content'), 20);
+        add_filter('the_content', array($this, 'easy_footnote_reset'), 999);
+        add_action('wp_enqueue_scripts', array($this, 'register_qtip_scripts'));
+        add_action('admin_menu', array($this, 'easy_footnotes_admin_actions'));
+        add_action('admin_enqueue_scripts', array($this, 'easy_footnotes_admin_scripts'));
 
-		add_option('easy_footnotes_options', $this->footnoteSettings);
-		add_shortcode( 'note', array($this, 'easy_footnote_shortcode') );
-		add_filter('the_content', array($this, 'easy_footnote_after_content'), 20);
-		add_filter('the_content', array($this, 'easy_footnote_reset'), 999);
-		add_action('wp_enqueue_scripts', array($this, 'register_qtip_scripts'));
-		add_action('admin_menu', array($this, 'easy_footnotes_admin_actions'));
-		add_action( 'admin_enqueue_scripts', array($this, 'easy_footnotes_admin_scripts') );
-		add_action('updated_option', array($this, 'easy_footnotes_options_updated'), 10, 3);
+        $this->footnoteOptions = get_option('easy_footnotes_options');
+    }
 
-		$this->footnoteOptions = get_option('easy_footnotes_options');
+    public function register_qtip_scripts()
+    {
+        wp_register_script('imagesloaded', plugins_url('/assets/qtip/imagesloaded.pkgd.min.js', __FILE__), null, false, true);
+        wp_register_script('qtip', plugins_url('/assets/qtip/jquery.qtip.min.js', __FILE__), array('jquery', 'imagesloaded'), false, true);
+        wp_register_script('qtipcall', plugins_url('/assets/qtip/jquery.qtipcall.js', __FILE__), array('jquery', 'qtip'), false, true);
+        wp_register_style('qtipstyles', plugins_url('/assets/qtip/jquery.qtip.min.css', __FILE__), null, false, false);
+        wp_register_style('easyfootnotescss', plugins_url('/assets/easy-footnotes.css', __FILE__), null, false, false);
+    }
 
-	}
+    public function easy_footnote_shortcode($atts, $content = null)
+    {
+        if ($this->footnoteOptions['show_easy_footnote_on_front']) {
+            $b_ShowOnFront = is_front_page();
+        } else {
+            $b_ShowOnFront = false;
+        }
 
+        wp_enqueue_style('qtipstyles');
+        wp_enqueue_style('easyfootnotescss');
+        wp_enqueue_script('imagesloaded');
+        wp_enqueue_script('qtip');
+        wp_enqueue_script('qtipcall');
+        wp_enqueue_style('dashicons');
 
-	public function easy_footnotes_options_updated( $option_name, $old_value, $option_value ) {
-	        
-	    if (array_key_exists($option_name, $this->footnoteSettings)) {
-			$this->footnoteOptions = get_option('easy_footnotes_options');
-	    }
+        extract(shortcode_atts(array(
+        ), $atts));
 
-	}
+        $post_id = get_the_ID();
 
-	public function register_qtip_scripts() {
-		wp_register_script( 'imagesloaded', plugins_url( '/assets/qtip/imagesloaded.pkgd.min.js' , __FILE__ ), null, false, true );
-		wp_register_script( 'qtip', plugins_url( '/assets/qtip/jquery.qtip.min.js' , __FILE__ ), array('jquery', 'imagesloaded'), false, true );
-		wp_register_script( 'qtipcall', plugins_url( '/assets/qtip/jquery.qtipcall.js' , __FILE__ ), array('jquery', 'qtip'), false, true );
-		wp_register_style( 'qtipstyles', plugins_url( '/assets/qtip/jquery.qtip.min.css' , __FILE__ ), null, false, false );
-		wp_register_style( 'easyfootnotescss', plugins_url( '/assets/easy-footnotes.css' , __FILE__ ), null, false, false );
-	}
+        $content = do_shortcode($content);
 
-	public function easy_footnote_shortcode($atts, $content = null) {
+        $count = $this->footnoteCount;
+        
+        // Increment the counter
+        $count++;
 
-		$footnoteOptions = $this->footnoteOptions; //get_option('easy_footnotes_options');
+        // Set the footnoteCount (This whole process needs reworked)
+        $this->footnoteCount = $count;
 
-		$b_ShowOnFront = false;
+        //$this->easy_footnote_count($this->footnoteCount, get_the_ID());
+        $this->easy_footnote_content($content);
 
-		if ( isset($footnoteOptions['show_easy_footnote_on_front']) && $footnoteOptions['show_easy_footnote_on_front'] ) {
-			$b_ShowOnFront = is_front_page();
-		}
+        if ((is_singular() || $b_ShowOnFront) && is_main_query()) {
+            $footnoteLink = '#easy-footnote-bottom-'.$this->footnoteCount.'-'.$post_id;
+            ;
+        } else {
+            $footnoteLink = get_permalink(get_the_ID()).'#easy-footnote-bottom-'.$this->footnoteCount.'-'.$post_id;
+        }
 
-		wp_enqueue_style( 'qtipstyles' );
-		wp_enqueue_style( 'easyfootnotescss' );
-		wp_enqueue_script( 'imagesloaded' );
-		wp_enqueue_script( 'qtip' );
-		wp_enqueue_script( 'qtipcall' );
-		wp_enqueue_style( 'dashicons' );
+        $footnoteContent = "<span id='easy-footnote-".esc_attr($this->footnoteCount).'-'.$post_id."' class='easy-footnote-margin-adjust'></span><span class='easy-footnote'><a href='".esc_url($footnoteLink)."' title='".htmlspecialchars($content, ENT_QUOTES)."'><sup>".esc_html($this->footnoteCount)."</sup></a></span>";
 
-		extract (shortcode_atts(array(
-		), $atts));
+        return $footnoteContent;
+    }
 
-		$post_id = get_the_ID();
+    public function easy_footnote_content($content)
+    {
+        $this->footnotes[$this->footnoteCount] = $content;
 
-		$content = do_shortcode($content);
+        return $this->footnotes;
+    }
 
-		$count = $this->footnoteCount;
-		
-		// Increment the counter
-		$count++;
+    public function easy_footnote_count($count, $currentPost)
+    {
+        if ($this->prevPost != $currentPost) {
+            $count = 0;
+        }
 
-		// Set the footnoteCount (This whole process needs reworked)
-		$this->footnoteCount = $count;
+        $this->prevPost = $currentPost;
 
-		//$this->easy_footnote_count($this->footnoteCount, get_the_ID());
-		$this->easy_footnote_content($content);
+        $count++;
 
-		if (( is_singular() || $b_ShowOnFront ) && is_main_query()) {
-			$footnoteLink = '#easy-footnote-bottom-'.$this->footnoteCount.'-'.$post_id;;
-		} else {
-			$footnoteLink = get_permalink(get_the_ID()).'#easy-footnote-bottom-'.$this->footnoteCount.'-'.$post_id;
-		}
+        $this->footnoteCount = $count;
 
-		$footnoteContent = "<span id='easy-footnote-".esc_attr($this->footnoteCount).'-'.$post_id."' class='easy-footnote-margin-adjust'></span><span class='easy-footnote'><a href='".esc_url($footnoteLink)."' title='".htmlspecialchars($content, ENT_QUOTES)."'><sup>".esc_html($this->footnoteCount)."</sup></a></span>";
+        return $this->footnoteCount;
+    }
 
-		return $footnoteContent;
-	}
+    public function easy_footnote_after_content($content)
+    {
+        if ($this->footnoteOptions['hide_easy_footnote_after_posts']) {
+            return $content;
+        }
 
-	public function easy_footnote_content($content) {
-		$this->footnotes[$this->footnoteCount] = $content;
+        if ($this->footnoteOptions['show_easy_footnote_on_front']) {
+            $b_ShowOnFront = is_front_page();
+        } else {
+            $b_ShowOnFront = false;
+        }
 
-		return $this->footnotes;
-	}
+        if ((is_singular() || $b_ShowOnFront) && is_main_query()) {
+            $footnotesInsert = $this->footnotes;
 
-	public function easy_footnote_count($count, $currentPost) {
-		if ($this->prevPost != $currentPost) {
-			$count = 0;
-		}
+            $footnoteCopy = '';
 
-		$this->prevPost = $currentPost;
+            $useLabel = $this->footnoteOptions['useLabel'];
+            $efLabel = $this->footnoteOptions['footnoteLabel'];
 
-		$count++;
+            $post_id = get_the_ID();
 
-		$this->footnoteCount = $count;
+            foreach ($footnotesInsert as $count => $footnote) {
+                $footnoteCopy .= '<li class="easy-footnote-single"><span id="easy-footnote-bottom-'.esc_attr($count).'-'.$post_id.'" class="easy-footnote-margin-adjust"></span>'.wp_kses_post($footnote).'<a class="easy-footnote-to-top" href="'.esc_url('#easy-footnote-'.$count.'-'.$post_id).'"></a></li>';
+            }
+            if (!empty($footnotesInsert)) {
+                if ($useLabel === true) {
+                    $content .= '<div class="easy-footnote-title"><h4>'.esc_html($efLabel).'</h4></div><ol class="easy-footnotes-wrapper">'.$footnoteCopy.'</ol>';
+                } else {
+                    $content .= '<ol class="easy-footnotes-wrapper">'.$footnoteCopy.'</ol>';
+                }
+            }
+        }
+        
+        return $content;
+    }
 
-		return $this->footnoteCount;
-	}
+    /**
+     * Reset the footnote count and footnote array each time the_content has been run.
+     */
+    public function easy_footnote_reset($content)
+    {
+        $this->footnoteCount = 0;
 
-	public function easy_footnote_after_content($content) {
+        $this->footnotes = array();
 
-		$footnoteOptions = $this->footnoteOptions; //get_option('easy_footnotes_options');
-		
-		$b_ShowOnFront = false;
+        return $content;
+    }
 
-		if ( isset($footnoteOptions['hide_easy_footnote_after_posts']) && $footnoteOptions['hide_easy_footnote_after_posts'] ) {
-			return $content;
-		}
+    // Functions to create Reading Time admin pages
+    public function easy_footnotes_admin()
+    {
+        include('easy-footnotes-admin.php');
+    }
 
-		if ( isset($footnoteOptions['show_easy_footnote_on_front']) && $footnoteOptions['show_easy_footnote_on_front'] ) {
-			$b_ShowOnFront = is_front_page();
-		}
+    public function easy_footnotes_admin_actions()
+    {
+        add_options_page("Easy Footnotes Settings", "Easy Footnotes", "manage_options", "easy-footnotes-settings", array($this, "easy_footnotes_admin"));
+    }
 
-		if ( ( is_singular() || $b_ShowOnFront ) && is_main_query() ) {
-			$footnotesInsert = $this->footnotes;
+    public function easy_footnotes_admin_scripts()
+    {
+        wp_enqueue_style('easy-footnotes-admin-styles', plugins_url('/assets/easy-footnotes-admin.css', __FILE__), '', '1.0.13');
 
-			$footnoteCopy = '';
-
-			$useLabel = $footnoteOptions['useLabel'];
-			$efLabel = $footnoteOptions['footnoteLabel'];
-
-			$post_id = get_the_ID();
-
-			foreach ($footnotesInsert as $count => $footnote) {
-				$footnoteCopy .= '<li class="easy-footnote-single"><span id="easy-footnote-bottom-'.esc_attr($count).'-'.$post_id.'" class="easy-footnote-margin-adjust"></span>'.wp_kses_post($footnote).'<a class="easy-footnote-to-top" href="'.esc_url('#easy-footnote-'.$count.'-'.$post_id).'"></a></li>';
-			}
-			if (!empty($footnotesInsert)) {
-				if ($useLabel === true) {
-					$content .= '<div class="easy-footnote-title"><h4>'.esc_html($efLabel).'</h4></div><ol class="easy-footnotes-wrapper">'.$footnoteCopy.'</ol>';
-				} else {
-					$content .= '<ol class="easy-footnotes-wrapper">'.$footnoteCopy.'</ol>';
-				}
-			}
-
-		}
-		
-		return $content;
-	}
-
-	/**
-	 * Reset the footnote count and footnote array each time the_content has been run.
-	 */
-	public function easy_footnote_reset($content) {
-		$this->footnoteCount = 0;
-
-		$this->footnotes = array();
-
-		return $content;
-	}
-
-	// Functions to create Reading Time admin pages
-	public function easy_footnotes_admin() {
-	    include('easy-footnotes-admin.php');
-	}
-
-	public function easy_footnotes_admin_actions() {
-		add_options_page("Easy Footnotes Settings", "Easy Footnotes", "manage_options", "easy-footnotes-settings", array($this, "easy_footnotes_admin"));
-	}
-
-	public function easy_footnotes_admin_scripts() {
-		wp_enqueue_style( 'easy-footnotes-admin-styles', plugins_url( '/assets/easy-footnotes-admin.css' , __FILE__ ), '', '1.0.13' );
-
-	    wp_register_script('easy-footnotes-admin-scripts', plugins_url( '/assets/js/easy-footnotes-admin.js' , __FILE__ ), array( 'jquery' ), '1.0.1' );
-		wp_enqueue_script( 'easy-footnotes-admin-scripts' );
-	}
-
+        wp_register_script('easy-footnotes-admin-scripts', plugins_url('/assets/js/easy-footnotes-admin.js', __FILE__), array( 'jquery' ), '1.0.1');
+        wp_enqueue_script('easy-footnotes-admin-scripts');
+    }
 }
 
 $easyFootnotes = new easyFootnotes();


### PR DESCRIPTION
Hi,

Yes. This is my first pull-request on Github. Hopefully I'm doing this right.

I came across your plugin while trying to replace a deprecated WordPress footnotes plugin. The current plugin satisfied almost all the requirements except for one: Showing the footnotes on the Front page. 

**Show Footnotes on Front**
There was a request from a user to [show the footnotes on the Index page](https://wordpress.org/support/topic/footnotes-at-bottom-of-post-not-appearing-on-index-page/). To get the ball rolling, I added the option to show the footnotes on the front-page. 

**Admin Options UI Change**
Besides the new checkbox, asking the user if they want to show the footnotes on the front page, there's a small UI tweak to improve usability. When the user checks "Hide Footnotes after post content" option, there's no reason to give the user the option to also check "Show Footnotes on Front Page". I added a new JS file that's loaded on the admin page to disable/enable the "Show Footnotes on Front Page" accordingly using jQuery. This JS file can be used to further enhance the Admin panel in future releases.

**Misc Changes**
Changed $footnoteSettings to a private var so that it can eventually be set/get in easy-footnotes-admin.php, and avoid hard-coding the array option keys in two places. The options are now loaded into $footnoteSettings in the constructor using get_option(). Last but not least, I used the "Sublime PHP CS Fixer" package as my PHP Build process and changed the coding style to follow the PSR-1 and PSR-2 standards. There are still some wrapping issues, which break PSR-2, but it's a good start.

Thanks,
Arbi
@arzoum
