### PR TITLE
Added before_footnote and after_footnote filters

### DIFF
--- a/easy-footnotes.php
+++ b/easy-footnotes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Footnotes
  * Plugin URI: https://jasonyingling.me/easy-footnotes-wordpress/
  * Description: Easily add footnotes to your posts with a simple shortcode.
- * Version: 1.0.16
+ * Version: 1.0.17b
  * Author: Jason Yingling
  * Author URI: https://jasonyingling.me
  * License: GPL2
@@ -86,7 +86,7 @@ class easyFootnotes
         $content = do_shortcode($content);
 
         $count = $this->footnoteCount;
-        
+
         // Increment the counter
         $count++;
 
@@ -159,11 +159,19 @@ class easyFootnotes
                 if ($useLabel === true) {
                     $content .= '<div class="easy-footnote-title"><h4>'.esc_html($efLabel).'</h4></div><ol class="easy-footnotes-wrapper">'.$footnoteCopy.'</ol>';
                 } else {
-                    $content .= '<ol class="easy-footnotes-wrapper">'.$footnoteCopy.'</ol>';
+                    // add before footnote filter
+                    $footnote_content = '';
+                    $footnote_content = apply_filters( 'before_footnote', $footnote_content );
+
+                    $footnote_content .= '<ol class="easy-footnotes-wrapper">'.$footnoteCopy.'</ol>';
+
+                    // add after footnote filter:
+                    $footnote_content = apply_filters( 'after_footnote', $footnote_content );
+
+                    $content .= do_shortcode($footnote_content);
                 }
             }
         }
-        
         return $content;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yingling017, twinpictures
 Donate link: http://jasonyingling.me
 Tags: footnotes, read, blogging, hover, tooltips, editing, endnotes, Formatting, writing, bibliography, notes, reference
 Requires at least: 3.0.1
-Tested up to: 4.9.9
+Tested up to: 5.0-alpha-43773
 Stable tag: 1.0.17a
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Easy Footnotes ===
-Contributors: yingling017
+Contributors: yingling017, twinpictures
 Donate link: http://jasonyingling.me
 Tags: footnotes, read, blogging, hover, tooltips, editing, endnotes, Formatting, writing, bibliography, notes, reference
 Requires at least: 3.0.1
-Tested up to: 4.9.5
-Stable tag: 1.0.16
+Tested up to: 4.9.9
+Stable tag: 1.0.17a
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -57,6 +57,9 @@ Maecenas sed diam eget risus varius blandit sit amet non magna. Integer posuere 
 2. Several footnotes (feetnote?) at the bottom of the post.
 
 == Changelog ==
+
+= 1.0.17 =
+* added ‘easy_footnote’ hook to filter footnotes
 
 = 1.0.16 =
 * Fixing footnote counts for the last time! (Hopefully)


### PR DESCRIPTION
Addes two filters to allow users to add content before and after the footes section.
here is a thread that explains the issue:
https://wordpress.org/support/topic/easy-footnotes-not-collapsed-hidden/

and a demo showing how the filters might be used:
https://spacedonkey.de/3320/collapse-o-matic-and-easy-footnotes-test/
