### PR TITLE
add ability to start from custom number

### DIFF
--- a/easy-footnotes.php
+++ b/easy-footnotes.php
@@ -59,7 +59,7 @@ class easyFootnotes {
 		add_shortcode( 'note', array( $this, 'easy_footnote_shortcode' ) );
 		add_shortcode( 'efn_note', array( $this, 'easy_footnote_shortcode' ) );
 		add_filter( 'the_content', array( $this, 'easy_footnote_after_content' ), 20 );
-		add_filter( 'the_content', array( $this, 'easy_footnote_reset' ), 999 );
+		add_filter( 'the_content', array( $this, 'easy_footnote_reset' ), -10 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_qtip_scripts' ) );
 		add_action( 'admin_menu', array( $this, 'easy_footnotes_admin_actions' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'easy_footnotes_admin_scripts' ) );
@@ -168,6 +168,11 @@ class easyFootnotes {
 
 			$post_id = get_the_ID();
 
+			$ppost = get_post($post_id);
+			$pcontent = $ppost->post_content;
+			$start_number = ( 1 === preg_match( "|<!\-\-startnum=(\d+)\-\->|", $pcontent,$start_number_array ) ) ? $start_number_array[ 1 ] : 1;
+			$number_label = $start_number;
+
 			foreach ( $footnotesInsert as $count => $footnote ) {
 				$footnoteCopy .= '<li class="easy-footnote-single"><span id="easy-footnote-bottom-' .esc_attr( $count ) . '-' . $post_id . '" class="easy-footnote-margin-adjust"></span>' . wp_kses_post( $footnote ) . '<a class="easy-footnote-to-top" href="' . esc_url( '#easy-footnote-' . $count . '-' . $post_id ) . '"></a></li>';
 			}
@@ -207,8 +212,11 @@ class easyFootnotes {
 	 * @param string $content The content of the post from the_content filter.
 	 */
 	public function easy_footnote_reset( $content ) {
-		$this->footnoteCount = 0;
-
+		$post = get_post($post_id);
+		$pcontent = $post->post_content;
+		$start_number = ( 1 === preg_match( "|<!\-\-startnum=(\d+)\-\->|", $content,$start_number_array ) ) ? $start_number_array[ 1 ] : 1;
+		$this->footnoteCount = $start_number - 1; //$this->footnoteCount;
+		
 		$this->footnotes = array();
 
 		return $content;

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ Easy Footnotes lets you quickly and easily add footnotes throughout your WordPre
 == Description ==
 
 Easy Footnotes lets you add footnotes throughout your WordPress posts by using the shortcode [efn_note]Footnote content.[/efn_note]. Easy Footnotes will automatically add the number of the footnote where the shortcode was entered and add the full footnote text to the bottom of your post in an ordered list with a corresponding number.
+If you wish to start the footnote from a custom number on a particular post, e.g. 7, simply add the code <!--startnum=7--> at the top of your post.
 
 Hovering the footnote label will show the user the full text of the footnote using the jQuery Qtip2 plugin. Clicking on the footnote label will take the user down the page to the corresponding footnote at the bottom of the WordPress post. Each footnote at the bottom of the post has a icon that can be clicked to return to that particular footnote within the post copy.
 


### PR DESCRIPTION
This feature will allow adding <!--startnum=7--> to the start of a post, so the starting number can be chosen. May be useful if you don't want each posts' footnotes to start again from 1. I have it tested and working so far on one site. Not sure if the changes I make would break anything else. Please let me know and feel free to edit or bounce it back to me if there is a problem!
Thanks for the great plugin!