### PR TITLE
Improve I18N Issues (Based on 1.1.6)

### DIFF
--- a/easy-footnotes-admin.php
+++ b/easy-footnotes-admin.php
@@ -58,7 +58,7 @@ if ( isset( $_POST['easy_footnote_hidden'] ) ) {
 		<p id="easy_footnote_on_front"><?php esc_html_e( 'Show Footnotes on Front Page: ', 'easy-footnotes' ); ?><input type="checkbox" name="show_easy_footnote_on_front" <?php checked( $show_easy_footnote_on_front ); ?> size="20"></p>
 
 		<p class="submit">
-		<input type="submit" name="Submit" value="<?php esc_attr_e( 'Update Options', 'easy_footnotes_trdom' ); ?>" />
+		<input type="submit" name="Submit" value="<?php esc_attr_e( 'Update Options', 'easy-footnotes' ); ?>" />
 		</p>
 	</form>
 

--- a/easy-footnotes.php
+++ b/easy-footnotes.php
@@ -3,6 +3,7 @@
  * Plugin Name: Easy Footnotes
  * Plugin URI: https://jasonyingling.me/easy-footnotes-wordpress/
  * Description: Easily add footnotes to your posts with a simple shortcode.
+ * Text Domain: easy-footnotes
  * Version: 1.1.6
  * Author: Jason Yingling
  * Author URI: https://jasonyingling.me


### PR DESCRIPTION
- This plugin’s `Requires at least` is below 4.6. so the developer needs to set a Text Domain in **easy-footnotes.php**, and it needs to be `easy-footnotes` to internationalize this plugin correctly! Please refer to this [official article](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains).
- Requires at least (3.0.1) is below 4.6, so a `load_plugin_textdomain` is **NEEDED**. Please make sure you load it at a certain point in your plugin. Please refer to this [official article](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain). I DO NOT make this modification because I don't know your function naming rule, so please do it by yourself.
- Fix the UI string with the wrong text domain.