### PR TITLE
Make the easy_footnote_reset action optional based on a setting

### DIFF
--- a/easy-footnotes-admin.php
+++ b/easy-footnotes-admin.php
@@ -17,12 +17,14 @@ if ( isset( $_POST['easy_footnote_hidden'] ) ) {
 		$easyFootnoteCheck              = isset( $_POST['easy_footnote_check'] ) ? true : false;
 		$hide_easy_footnote_after_posts = isset( $_POST['hide_easy_footnote_after_posts'] ) ? true : false;
 		$show_easy_footnote_on_front    = isset( $_POST['show_easy_footnote_on_front'] ) ? true : false;
+		$reset_footnotes                = isset( $_POST['reset_footnotes'] ) ? true : false;
 
 		$updateOptions = array(
 			'footnoteLabel'                  => sanitize_text_field( $easyFootnoteLabel ),
 			'useLabel'                       => $easyFootnoteCheck,
 			'hide_easy_footnote_after_posts' => $hide_easy_footnote_after_posts,
 			'show_easy_footnote_on_front'    => $show_easy_footnote_on_front,
+			'reset_footnotes'                => $reset_footnotes,
 		);
 
 		update_option( 'easy_footnotes_options', $updateOptions );
@@ -38,6 +40,7 @@ if ( isset( $_POST['easy_footnote_hidden'] ) ) {
 	$easyFootnoteCheck              = isset( $footnoteOptions['useLabel'] ) ? $footnoteOptions['useLabel'] : false;
 	$hide_easy_footnote_after_posts = isset( $footnoteOptions['hide_easy_footnote_after_posts'] ) ? $footnoteOptions['hide_easy_footnote_after_posts'] : false;
 	$show_easy_footnote_on_front    = isset( $footnoteOptions['show_easy_footnote_on_front'] ) ? $footnoteOptions['show_easy_footnote_on_front'] : false;
+	$reset_footnotes                = isset( $footnoteOptions['reset_footnotes'] ) ? $footnoteOptions['reset_footnotes'] : false;
 }
 ?>
 
@@ -55,7 +58,10 @@ if ( isset( $_POST['easy_footnote_hidden'] ) ) {
 
 		<p><?php esc_html_e( 'Hide Footnotes after post content: ', 'easy-footnotes' ); ?><input type="checkbox" name="hide_easy_footnote_after_posts" <?php checked( $hide_easy_footnote_after_posts ); ?> size="20"></p>
 
+		<p><?php esc_html_e( 'Reset Footnotes to avoid duplication after the content: ', 'easy-footnotes' ); ?><input type="checkbox" name="reset_footnotes" <?php checked( $reset_footnotes ); ?> size="20"></p>
+
 		<p id="easy_footnote_on_front"><?php esc_html_e( 'Show Footnotes on Front Page: ', 'easy-footnotes' ); ?><input type="checkbox" name="show_easy_footnote_on_front" <?php checked( $show_easy_footnote_on_front ); ?> size="20"></p>
+
 
 		<p class="submit">
 		<input type="submit" name="Submit" value="<?php esc_attr_e( 'Update Options', 'easy-footnotes' ); ?>" />

--- a/easy-footnotes.php
+++ b/easy-footnotes.php
@@ -58,6 +58,7 @@ class easyFootnotes {
 			'useLabel'                       => false,
 			'hide_easy_footnote_after_posts' => false,
 			'show_easy_footnote_on_front'    => false,
+			'reset_footnotes'                => false,
 		);
 
 		add_option( 'easy_footnotes_options', $this->footnoteSettings );
@@ -65,7 +66,11 @@ class easyFootnotes {
 		add_shortcode( 'efn_note', array( $this, 'easy_footnote_shortcode' ) );
 		add_shortcode( 'efn_reset', array( $this, 'short_code_reset' ) );
 		add_filter( 'the_content', array( $this, 'easy_footnote_after_content' ), 20 );
-		add_filter( 'the_content', array( $this, 'easy_footnote_reset' ), 999 );
+		
+		$this->footnoteOptions = get_option( 'easy_footnotes_options' );
+		if ( isset( $this->footnoteOptions['reset_footnotes'] ) && $this->footnoteOptions['reset_footnotes'] ) {
+			add_filter( 'the_content', array( $this, 'easy_footnote_reset' ), 999 );
+		}
 		
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_qtip_scripts' ) );
 		add_action( 'admin_menu', array( $this, 'easy_footnotes_admin_actions' ) );


### PR DESCRIPTION
Fixes #25

Make the `easy_footnote_reset` action optional based on a setting.

* Add a new checkbox setting for `reset_footnotes` in the admin form in `easy-footnotes-admin.php`.
* Save the new setting to the `easy_footnotes_options` array in `easy-footnotes-admin.php`.
* Retrieve the new setting value when displaying the admin form in `easy-footnotes-admin.php`.
* Add a new option `reset_footnotes` to the `footnoteSettings` array in `easy-footnotes.php`.
* Conditionally add the `easy_footnote_reset` filter based on the new setting in `easy-footnotes.php`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jasonyingling/easy-footnotes/pull/26?shareId=20b78c51-664c-4cb5-86aa-44afe9683d5b).